### PR TITLE
Actions

### DIFF
--- a/.github/workflows/build-prod-files.yml
+++ b/.github/workflows/build-prod-files.yml
@@ -1,0 +1,156 @@
+name: Build production files
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: "Name of the folder containing the PCB files. The generated production files will be at 'release/<name>'."
+        required: true
+        type: string
+      overwrite:
+        description: "Overwrite existing production files for this board"
+        required: false
+        type: boolean
+        default: false
+      erc:
+        description: "Include ERC output"
+        required: false
+        type: boolean
+        default: false
+      drc:
+        description: "Include DRC output"
+        required: false
+        type: boolean
+        default: false
+      sch_file:
+        description: "Main .kicad_sch file name, defaults to '<name>.kicad_sch'"
+        required: false
+        type: string
+      pcb_file:
+        description: "Main .kicad_pcb file name, defaults to '<name>.kicad_pcb'"
+        required: false
+        type: string
+      version:
+        description: "Version number to include in info file"
+        required: false
+        type: string
+        default: "v1.0"
+      fabrication:
+        description: "Manufacturer/fabrication provider name to include in info file"
+        required: false
+        type: string
+      n_layers:
+        description: "Number of layers to include in info file (note, gerbers are generated for every layer regardless of this setting)"
+        required: false
+        type: number
+
+permissions:
+  contents: read
+
+jobs:
+  init:
+    name: Initialise directory in release/ folder and check files exist
+    runs-on: ubuntu-24.04
+
+    outputs:
+      release_dir: ${{ steps.format.outputs.release_dir }}
+      sch_location: ${{ steps.format.outputs.sch_location }}
+      pcb_location: ${{ steps.format.outputs.pcb_location }}
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Format names
+        id: format
+        env:
+          NAME: ${{ inputs.name }}
+          SCH_FILE: ${{ inputs.sch_file }}
+          PCB_FILE: ${{ inputs.pcb_file }}
+        run: |
+          echo "release_dir=release/${NAME}" >> "$GITHUB_OUTPUT"
+          echo "sch_location=${NAME}/${SCH_FILE:-${NAME}.kicad_sch}" >> "$GITHUB_OUTPUT"
+          echo "pcb_location=${NAME}/${PCB_FILE:-${NAME}.kicad_pcb}" >> "$GITHUB_OUTPUT"
+
+      - name: Check schematic exists
+        env:
+          SCH_LOCATION: ${{ steps.format.outputs.sch_location }}
+        run: test -f "$SCH_LOCATION"
+
+      - name: Check PCB exists
+        env:
+          PCB_LOCATION: ${{ steps.format.outputs.pcb_location }}
+        run: test -f "$PCB_LOCATION"
+
+      - name: Check for existing release directory
+        if: inputs.overwrite == 'false' || inputs.overwrite == false
+        env:
+          RELEASE_DIR: ${{ steps.format.outputs.release_dir }}
+        run: test ! -e "$RELEASE_DIR"
+
+      - name: Setup release directory
+        env:
+          RELEASE_DIR: ${{ steps.format.outputs.release_dir }}
+        run: |
+          rm -rf "$RELEASE_DIR"
+          mkdir -p "$RELEASE_DIR"
+
+  gen_files:
+    name: Generate gerbers, schematic PDF and interactive BOM
+    runs-on: ubuntu-24.04
+    needs: init
+
+    permissions:
+      contents: write
+
+    container:
+      image: maartin0/kicadutils
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Add version to info
+        if: inputs.version != ''
+        env:
+          RELEASE_DIR: ${{ needs.init.outputs.release_dir }}
+          VERSION: ${{ inputs.version }}
+        run: echo "version=${VERSION}" >> "${RELEASE_DIR}/info"
+
+      - name: Add fabrication to info
+        if: inputs.fabrication != ''
+        env:
+          RELEASE_DIR: ${{ needs.init.outputs.release_dir }}
+          FABRICATION: ${{ inputs.fabrication }}
+        run: echo "fabrication=${FABRICATION}" >> "${RELEASE_DIR}/info"
+
+      - name: Add layers to info
+        if: inputs.n_layers != ''
+        env:
+          RELEASE_DIR: ${{ needs.init.outputs.release_dir }}
+          LAYERS: ${{ inputs.n_layers }}
+        run: echo "layers=${LAYERS}" >> "${RELEASE_DIR}/info"
+
+      - name: Generate files
+        env:
+          RELEASE_DIR: ${{ needs.init.outputs.release_dir }}
+          SCH_LOCATION: ${{ needs.init.outputs.sch_location }}
+          PCB_LOCATION: ${{ needs.init.outputs.pcb_location }}
+          RUN_ERC: ${{ inputs.erc }}
+          RUN_DRC: ${{ inputs.drc }}
+        run: |
+          ARGS=""
+          [ "$RUN_ERC" = "true" ] && ARGS="--erc"
+          [ "$RUN_DRC" = "true" ] && ARGS="$ARGS --drc"
+          ./bin/gen.sh "$SCH_LOCATION" "$PCB_LOCATION" "$RELEASE_DIR" $ARGS
+
+      - name: Commit changes
+        env:
+          NAME: ${{ inputs.name }}
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git config --global --add safe.directory "$(pwd)"
+          git add release/
+          git commit -m "Automatically generate $NAME production files"
+          git push

--- a/.github/workflows/disabled/test-all.yml
+++ b/.github/workflows/disabled/test-all.yml
@@ -1,0 +1,45 @@
+name: Test all projects
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test_erc:
+    name: Run KiCad ERC(s)
+    runs-on: ubuntu-24.04
+    container:
+      image: maartin0/kicadutils
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Run DRC(s)
+        run: find . -name "*.kicad_pcb" -print0 | xargs -0 -n1 sh -c './bin/test/drc.sh "$0" || exit 255'
+
+  test_drc:
+    name: Run KiCad DRC(s)
+    runs-on: ubuntu-24.04
+    container:
+      image: maartin0/kicadutils
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Run DRC(s)
+        run: find . -name "*.kicad_pcb" -print0 | xargs -0 -n1 sh -c './bin/test/drc.sh "$0" || exit 255'
+
+  test_relative:
+    name: Check for non-relative paths
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check for non-relative paths
+        run: find . -name "*-lib-table" -print0 | xargs -0 -n1 sh -c './bin/test/relative.sh "$0" || exit 255'

--- a/.github/workflows/test-changes.yml
+++ b/.github/workflows/test-changes.yml
@@ -1,0 +1,84 @@
+name: Test changed files
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    name: Get changed files
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
+    outputs:
+      changed: ${{ steps.changed-files.outputs.any_changed }}
+      all_changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
+
+  test_erc:
+    name: Run KiCad ERC(s)
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
+    container:
+      image: maartin0/kicadutils
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Run ERC(s)
+        env:
+          ALL_CHANGED_FILES: ${{ needs.changes.outputs.all_changed_files }}
+        run: |
+          for file in "${ALL_CHANGED_FILES}"; do
+            if echo "$file" | grep ".kicad_sch$" >/dev/null; then
+              ./bin/test/erc.sh "$file"
+            fi
+          done
+
+  test_drc:
+    name: Run KiCad DRC(s)
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
+    container:
+      image: maartin0/kicadutils
+
+    steps:
+      - name: Checkout to latest commit
+        uses: actions/checkout@v4
+
+      - name: Run DRC(s)
+        env:
+          ALL_CHANGED_FILES: ${{ needs.changes.outputs.all_changed_files }}
+        run: |
+          for file in "${ALL_CHANGED_FILES}"; do
+            if echo "$file" | grep ".kicad_pcb$" >/dev/null; then
+              ./bin/test/drc.sh "$file"
+            fi
+          done
+
+  test_relative:
+    name: Check for non-relative paths
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.changed == 'true'
+
+    steps:
+      - name: Check for non-relative paths
+        env:
+          ALL_CHANGED_FILES: ${{ needs.changes.outputs.all_changed_files }}
+        run: |
+          for file in "${ALL_CHANGED_FILES}"; do
+            if echo "$file" | grep "\-lib-table$" >/dev/null; then
+              ./bin/test/relative.sh "$file"
+            fi
+          done

--- a/bin/docker/Dockerfile
+++ b/bin/docker/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:24.04
+
+RUN apt-get update &&\
+ apt-get install -y software-properties-common zip unzip python3 python3-pip nodejs npm git &&\
+ add-apt-repository -y ppa:kicad/kicad-9.0-releases &&\
+ apt-get update &&\
+ apt-get install -y kicad &&\
+ python3 -m pip install InteractiveHtmlBom --break-system-packages

--- a/bin/docker/build.sh
+++ b/bin/docker/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+if ! [ -f "Dockerfile" ]; then
+    echo "Error: Make sure you're running this in the same directory as the Dockerfile"
+    exit 1
+fi
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <username>/<package name>"
+    exit 1
+fi
+
+docker build -t "$1" .
+docker push "$1"

--- a/bin/gen.sh
+++ b/bin/gen.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+set -e
+
+tmp_dir="$(date +"tmp-%Y.%m.%d-%H.%M.%S")"
+
+cleanup() {
+    rm -rf "$tmp_dir"
+}
+
+die() {
+    echo "$*"
+    cleanup
+    exit 1
+}
+
+if [ $# -lt 3 ]; then
+    die "Usage: $0 <sch> <pcb> <release dir> [--erc] [--drc]"
+fi
+
+sch="$1"
+shift
+test -f "$sch" || die "Schematic '$sch doesn't exist"
+pcb="$1"
+shift
+test -f "$pcb" || die "PCB '$pcb' doesn't exist"
+release_dir="$1"
+shift
+test -e "$release_dir" || die "Release dir '$release_dir' doesn't exist"
+
+while test $# -gt 0
+do
+    case "$1" in
+        --erc) RUN_ERC=1
+            ;;
+        --drc) RUN_DRC=1
+            ;;
+        *) die "Unreconised option $1"
+            ;;
+    esac
+    shift
+done
+
+mkdir -p "$tmp_dir"
+cd "$tmp_dir"
+
+# generate gerbers
+echo "../$pcb"
+kicad-cli pcb export gerbers "../$pcb"
+zip -r fabrication.zip ./*
+mv fabrication.zip "../$release_dir"
+#
+cd ..
+cleanup
+#
+INTERACTIVE_HTML_BOM_NO_DISPLAY=1 generate_interactive_bom "$pcb" --dest-dir "../$release_dir" --no-browser
+kicad-cli sch export pdf --output "$release_dir/schematic.pdf" "$sch"
+
+# gen erc-errors and drc-errors
+
+set +e # Don't abort if ERC/DRC fails
+[ "$RUN_ERC" = "1" ] && LOG_LOCATION="$release_dir/$(date +"erc-log-%Y.%m.%d-%H.%M.%S.txt")" ./bin/test/erc.sh "$sch"
+[ "$RUN_DRC" = "1" ] && LOG_LOCATION="$release_dir/$(date +"drc-log-%Y.%m.%d-%H.%M.%S.txt")" ./bin/test/drc.sh "$pcb"
+set -e

--- a/bin/test/drc.sh
+++ b/bin/test/drc.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+log="$(date +"drc-log-%Y.%m.%d-%H.%M.%S.txt")"
+
+cleanup() {
+    rm -f "$log"
+}
+
+die() {
+    echo "$*"
+    cleanup
+    exit 1
+}
+
+path="$1"
+
+if ! [ -f "$path" ]; then
+    die "'$path' does not exist"
+fi
+
+ext="$(basename "$path" | sed 's/^.*\.\(.*\)$/\1/')"
+
+if [ "$ext" != "kicad_pcb" ]; then
+    die "File extension must be 'kicad_pcb'"
+fi
+
+if ! kicad-cli pcb drc "$path" --output "$log" --severity-error --exit-code-violations; then
+    cat "$log"
+    [ -n "$LOG_LOCATION" ] && mv "$log" "$LOG_LOCATION"
+    die "Non-zero DRC errors"
+fi
+
+[ -n "$LOG_LOCATION" ] && mv "$log" "$LOG_LOCATION"
+
+cleanup

--- a/bin/test/erc.sh
+++ b/bin/test/erc.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -e
+
+log="$(date +"erc-log-%Y.%m.%d-%H.%M.%S.txt")"
+
+cleanup() {
+    rm -f "$log"
+}
+
+die() {
+    echo "$*"
+    cleanup
+    exit 1
+}
+
+path="$1"
+
+if ! [ -f "$path" ]; then
+    die "'$path' does not exist"
+fi
+
+ext="$(basename "$path" | sed 's/^.*\.\(.*\)$/\1/')"
+
+if [ "$ext" != "kicad_sch" ]; then
+    die "File extension must be 'kicad_sch'"
+fi
+
+if ! KICAD_SYMBOL_DIR="/usr/share/kicad/symbols" kicad-cli sch erc "$path" --output "$log" --severity-error --exit-code-violations; then
+    cat "$log"
+    [ -n "$LOG_LOCATION" ] && mv "$log" "$LOG_LOCATION"
+    die "Non-zero ERC errors"
+fi
+
+[ -n "$LOG_LOCATION" ] && mv "$log" "$LOG_LOCATION"
+
+cleanup

--- a/bin/test/relative.sh
+++ b/bin/test/relative.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+set -e
+
+log="$(date +"rel-log-%Y.%m.%d-%H.%M.%S.json")"
+
+cleanup() {
+    rm -f "$log"
+}
+
+die() {
+    if [ -n "$*" ]; then
+        echo "$*"
+    fi
+    cleanup
+    exit 1
+}
+
+path="$1"
+
+if ! [ -f "$path" ]; then
+    die "'$path' does not exist"
+fi
+
+if ! echo "$path" | grep "\-lib-table$" >/dev/null; then
+    die "expected filename ending in '-lib-table'"
+fi
+
+if grep "^ *(lib.*(uri \"[^\$]" "$path" > "$log"; then
+    echo "'$path' appears to not use a relative path:"
+    cat "$log"
+    die
+fi
+
+cleanup


### PR DESCRIPTION
This PR adds several different [GitHub actions](https://github.com/features/actions):

### Generate production files
Adds a workflow that can be manually triggered to generate production files for a specific project:

![image](https://github.com/user-attachments/assets/cda69e01-0db2-4324-b6f8-0b4304923714)

This generates the following:
- `release/<name>/fabrication.zip`
- `release/<name>/schematic.pdf`
- `release/<name>/ibom.html`

And optionally:
- `release/<name>/info`
- `release/<name>/erc-log-<timestamp>.txt`
- `release/<name>/drc-log-<timestamp>.txt`

Could also automatically run when a PR is accepted - but should this overwrite existing files?

### Tests on push to main branch
Fails if:
- There are any ERC or DRC *errors* for *all* KiCad projects
- There are any non-relative paths used in *any* `*-lib-table`

### Tests on commit/pull request
Fails if:
- There are any ERC or DRC *errors* for changed KiCad projects
- There are any non-relative paths used in any changed `*-lib-table` 

#### Example
![image](https://github.com/user-attachments/assets/9b386cd4-a050-4908-b36a-d3774c4adcec)

