### PR TITLE
fix(actions): Generating production files incorrectly failing with invalid permissions

### DIFF
--- a/.github/workflows/gen-release.yml
+++ b/.github/workflows/gen-release.yml
@@ -6,13 +6,46 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
+  check_for_permissions_error:
+    name: Send error if something is invalid
+    runs-on: ubuntu-24.04
+
+    if: contains(github.event.comment.body, '@github-actions generate') && !github.event.issue.pull_request || (github.event.comment.author_association != 'COLLABORATOR' && github.event.comment.author_association != 'OWNER' && github.event.comment.author_association != 'MEMBER')
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Not a pull request
+        if: github.event.issue.pull_request == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.url }}
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          pr_number="$(echo "$PR" | sed 's/.*\/issues\///')"
+          gh issue comment "$pr_number" --body "@$USER This command only works in a pull request"
+      
+      - name: No permission
+        if: github.event.issue.pull_request && github.event.comment.author_association != 'COLLABORATOR' && github.event.comment.author_association != 'OWNER' && github.event.comment.author_association != 'MEMBER'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.pull_request.url }}
+          USER: ${{ github.event.comment.user.login }}
+          ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          pr_number="$(echo "$PR" | sed 's/.*\/pulls\///')"
+          gh pr comment "$pr_number" --body "@$USER You don't have permission to run this command. You must be either a \`COLLABORATOR\`, \`MEMBER\` or \`OWNER\`. Your association: \`$ASSOCIATION\`."
+
   parse_message:
     name: Parse message body and check referenced files exist
     runs-on: ubuntu-24.04
 
-    if: github.event.issue.pull_request && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER') && contains(github.event.comment.body, '@github-actions generate')
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@github-actions generate') && (github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER')
 
     steps:
       - name: Checkout repo
@@ -135,3 +168,25 @@ jobs:
           [ "$CREATE_TAG" = "1" ] && git tag "${NAME}-${VERSION}"
           git push
           git push --tags
+
+  alert_on_error:
+    name: Send a message if this workflow fails
+    runs-on: ubuntu-24.04
+    needs: gen_files
+
+    if: always() && contains(needs.*.result, 'failure')
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Send message
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.issue.pull_request.url }}
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          pr_number="$(echo "$PR" | sed 's/.*\/pulls\///')"
+          gh pr comment "$pr_number" --body "@$USER This command failed. Check the error logs in the actions tab for more details."
+
+    

--- a/.github/workflows/suggest-gen.yml
+++ b/.github/workflows/suggest-gen.yml
@@ -34,9 +34,9 @@ jobs:
           set -e
 
           if [ "$exit_code" != "0" ]; then
-            echo "Non-zero exit code, error was:"
+            echo "Non-zero exit code ($exit_code), error was:"
             echo "$body"
-            exit "$exit_code"
+            exit 0 # Don't error - there may be no KiCad project in this pull request
           fi
 
           gh pr comment "$pr_number" --body "$body"

--- a/bin/gen/ibom.sh
+++ b/bin/gen/ibom.sh
@@ -18,4 +18,4 @@ pcb="$1"
 release_dir="$2"
 [ -d "$release_dir" ] || die "Release dir '$release_dir' doesn't exist or isn't a directory"
 
-INTERACTIVE_HTML_BOM_NO_DISPLAY=1 generate_interactive_bom "$pcb" --dest-dir "$start_dir/$release_dir" --no-browser
+INTERACTIVE_HTML_BOM_NO_DISPLAY=1 generate_interactive_bom --include-nets "$pcb" --dest-dir "$start_dir/$release_dir" --no-browser


### PR DESCRIPTION
Previously the `github-actions generate` command would only run if the commenting user's `author_association` was:
- `COLLABORATOR`
- `OWNER`

This PR:
- Adds `MEMBER` to that list
- Will send error messages if:
  - You run the command and do not have permission to run it.
  - The generation fails for any reason (e.g. typo in filename)
  - You try and run the command in an issue (which won't work since you aren't changing any files)
- When generating the iBOM, uses the `--include-nets` flag which is generally convenient and there aren't any negatives to include it

## Examples
![image](https://github.com/user-attachments/assets/833531f0-3e90-4243-9baa-876f0c41b480)

Typo in `pcb_location` (battak instead of batak as an example):
![image](https://github.com/user-attachments/assets/b15bf5a9-f63c-4c73-816f-96363d78a0bb)

Successful command:
![image](https://github.com/user-attachments/assets/5fa903f3-2edd-4d8f-8ecd-84a696d91774)

External user trying to use command:
![image](https://github.com/user-attachments/assets/80f925ab-7cc9-4a01-b43a-8e926e681977)



Resolves #132